### PR TITLE
Add testing workflow for rust implementation

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,0 +1,15 @@
+name: Test implementations for aoc 2024
+on:
+  push:
+    branches:
+      - 2024-rust
+      # We could also add `main` here if this is a long-lived branch
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test project
+        run: cargo test --verbose

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -9,7 +9,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          # We could also add `beta` and `nightly` here
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Rust ${{ matrix.toolchain }}
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: Test project
         run: cargo test --verbose


### PR DESCRIPTION
This workflow runs on every pull request and when a commit to `2024-rust` is pushed.
At the moment, it only runs the `stable` toolchain, but we could add `beta` and `nightly` too.

Let me know what you think